### PR TITLE
Use writefile in Vim to avoid screen flash

### DIFF
--- a/plugin/osc52.vim
+++ b/plugin/osc52.vim
@@ -78,9 +78,12 @@ endfunction
 " This function causes the terminal to flash as a side effect.  It would be
 " better if it didn't, but I can't figure out how.
 function! s:rawecho(str)
-  if has('nvim')
+  if filewritable('/dev/stderr')
+    " If possible, write the escape sequence directly to stderr.
     call writefile([a:str], '/dev/stderr', 'b')
   else
+    " Otherwise, fall back on a shell command to write the escape sequence. This
+    " requires a redraw and causes the screen to flash as a side effect.
     exec("silent! !echo " . shellescape(a:str))
     redraw!
   endif


### PR DESCRIPTION
NeoVim already uses this command, and it turns out it works file in
vanilla Vim as well, with no janky screen flash.

I left the shell-based version of this command in place just in case
/dev/stderr isn't writable for some reason.